### PR TITLE
🤖 Added check for the correct yq being installed 🤖

### DIFF
--- a/load.bash
+++ b/load.bash
@@ -5,6 +5,9 @@ command -v helm &> /dev/null || { echo >&2 'ERROR: helm not installed - Aborting
 command -v oc &> /dev/null || { echo >&2 'ERROR: oc not installed - Aborting'; exit 1; }
 command -v conftest &> /dev/null || { echo >&2 'ERROR: conftest not installed - Aborting'; exit 1; }
 
+# Two versions of yq exist, check its the correct one
+[[ $(yq --help | grep -c "jq wrapper") -eq 1 ]] || { echo >&2 'ERROR: found yq installed but not the jq wrapper version (https://github.com/kislyuk/yq) - Aborting'; exit 1; }
+
 # shellcheck disable=SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/src/yaml-json-manipulation.bash"
 


### PR DESCRIPTION
#### What is this PR About?
Sadly there are two yq binaries in the wild. 
- the brew one (https://github.com/mikefarah/yq) which uses its own syntax to update yaml
- the pip one (https://github.com/kislyuk/yq) which is a wrapper around jq.

I prefer the wrapper one, as it means I don't need to learn another syntax if I can '_JQ it_' i can '_YQ it'_.

This PR adds an extra check to make sure its the correct yq.

#### How do we test this?
Action stays green.

cc: @redhat-cop/bats-library
