### PR TITLE
Added code to not process a template if required params are found

### DIFF
--- a/test/data/template-required-params-expected.yml
+++ b/test/data/template-required-params-expected.yml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: ${NAME}
+    app.kubernetes.io/instance: Bar
+    app.kubernetes.io/component: FooBar
+    app.kubernetes.io/part-of: Foo
+    app.kubernetes.io/managed-by: Bar
+  name: NoApiGroup
+roleRef: null
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: Foo
+    app.kubernetes.io/instance: Bar
+    app.kubernetes.io/component: FooBar
+    app.kubernetes.io/part-of: Foo
+    app.kubernetes.io/managed-by: Bar
+  name: NoKind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io

--- a/test/data/template-required-params-input.yml
+++ b/test/data/template-required-params-input.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Template
+objects:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/name: ${NAME}
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: NoApiGroup
+  roleRef:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: NoKind
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+parameters:
+  - name: NAME
+    value: Foo
+    required: true

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -22,6 +22,15 @@ load load
   [ "$status" -eq 0 ]
 }
 
+@test "split_files - OCP Template.yml with required params" {
+  tmp=$(split_files "test/data/template-required-params-input.yml")
+
+  run diff "${tmp}/template-required-params-input.yml" test/data/template-required-params-expected.yml
+
+  echo "${output}"
+  [ "$status" -eq 0 ]
+}
+
 @test "split_files - Single JSON" {
   tmp=$(split_files "test/data/json-root.json" "true")
 


### PR DESCRIPTION
#### What is this PR About?
The downstream repos (containers-quickstarts / openshift-templates / container-pipelines) contain templates with required params. Since templates are on the way out, I didn't see the point in implementing code to allow for those params to be set, so thought best to just skip over. If no required params are found, it will process the template.


#### How do we test this?
GREEEEEEN

cc: @redhat-cop/bats-library
