### PR TITLE
Added handling of files in sub-dirs

### DIFF
--- a/test/data/multiple-subs/a/list-input.yml
+++ b/test/data/multiple-subs/a/list-input.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: NoApiGroup
+  roleRef:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: NoKind
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io

--- a/test/data/multiple-subs/b/list-input.yml
+++ b/test/data/multiple-subs/b/list-input.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: NoApiGroup
+  roleRef:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: NoKind
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -47,6 +47,19 @@ load load
 
   echo "${output}"
   [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "list-input.yml" ]
+  [ "${lines[1]}" = "template-input.yml" ]
+}
+
+@test "split_files - Directory with sub directories containing same filenames" {
+  tmp=$(split_files "test/data/multiple-subs")
+
+  run ls "${tmp}"
+
+  echo "${output}"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "a_list-input.yml" ]
+  [ "${lines[1]}" = "b_list-input.yml" ]
 }
 
 @test "print_info" {


### PR DESCRIPTION
#### What is this PR About?
If the same filename was in multiple sub directories, only 1 file would survive as the structure is flattened. This PR still flattens the structure, but updates the filename to contain those dirs in it.

Requires https://github.com/redhat-cop/bats-library/pull/18 merged first.

#### How do we test this?
Green action

cc: @redhat-cop/bats-library
