### PR TITLE
Added yaml file extension to supported files for 'split_files'

### DIFF
--- a/src/yaml-json-manipulation.bash
+++ b/src/yaml-json-manipulation.bash
@@ -27,7 +27,7 @@ split_files() {
   fi
 
   # shellcheck disable=SC2038
-  for file in $(find "${search_path}" \( -name "*.yml" -o -name "*.json" \) -type f | xargs); do
+  for file in $(find "${search_path}" \( -name "*.yml" -o -name "*.yaml" -o -name "*.json" \) -type f | xargs); do
     # Resolve the key from the file
     local key
     if [[ -z "${dont_resolve_key}" ]]; then
@@ -40,7 +40,7 @@ split_files() {
     fi
 
     local yq_opts
-    if [[ "${file#*.}" == "yml" ]]; then
+    if [[ "${file#*.}" == "yml" ]] || [[ "${file#*.}" == "yaml" ]] ; then
       yq_opts="--yaml-output"
     fi
 

--- a/test/data/list-expected.yaml
+++ b/test/data/list-expected.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: Foo
+    app.kubernetes.io/instance: Bar
+    app.kubernetes.io/component: FooBar
+    app.kubernetes.io/part-of: Foo
+    app.kubernetes.io/managed-by: Bar
+  name: NoApiGroup
+roleRef: null
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: Foo
+    app.kubernetes.io/instance: Bar
+    app.kubernetes.io/component: FooBar
+    app.kubernetes.io/part-of: Foo
+    app.kubernetes.io/managed-by: Bar
+  name: NoKind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io

--- a/test/data/list-input.yaml
+++ b/test/data/list-input.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: NoApiGroup
+  roleRef:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    labels:
+      app.kubernetes.io/name: Foo
+      app.kubernetes.io/instance: Bar
+      app.kubernetes.io/component: FooBar
+      app.kubernetes.io/part-of: Foo
+      app.kubernetes.io/managed-by: Bar
+    name: NoKind
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -13,6 +13,15 @@ load load
   [ "$status" -eq 0 ]
 }
 
+@test "split_files - k8s List.yaml" {
+  tmp=$(split_files "test/data/list-input.yaml")
+
+  run diff "${tmp}/list-input.yaml" test/data/list-expected.yaml
+
+  echo "${output}"
+  [ "$status" -eq 0 ]
+}
+
 @test "split_files - OCP Template.yml" {
   tmp=$(split_files "test/data/template-input.yml")
 


### PR DESCRIPTION
#### What is this PR About?
Adds support for .yaml when splitting files.

Fixes: https://github.com/redhat-cop/pelorus/pull/149

#### How do we test this?
Action stays green.

cc: @redhat-cop/bats-library
