### PR TITLE
Removed rm from testing docs as no longer needed

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -7,8 +7,8 @@ All test data should be added under [data.](test/data).
 
 ## Execute Locally
 ```bash
-rm -rf /tmp/rhcop; bats test/tests.sh
-rm -rf /tmp/rhcop; bats test/tests_fail.sh
+bats test/tests.sh
+bats test/tests_fail.sh
 ```
 
 ## CI Linting


### PR DESCRIPTION
#### What is this PR About?
Minor tweak to docs. the bats test already includes removing any data that might overlap:
- https://github.com/redhat-cop/bats-library/blob/master/test/tests.sh#L7-L9

cc: @redhat-cop/bats-library
