### PR TITLE
changed finding the package line to be grep based instead of 1st line

### DIFF
--- a/src/conftest.bash
+++ b/src/conftest.bash
@@ -36,7 +36,8 @@ get_rego_namespaces() {
 
   # shellcheck disable=SC2038
   for file in $(find policy/* -name "*.rego" -type f | xargs); do
-    read -r line < "${file}"
+    local line
+    line="$(grep -P "^package " "${file}")"
 
     local current
     current="$(echo "${line/package/}" | xargs)"


### PR DESCRIPTION
#### What is this PR About?
fixes:
- https://github.com/redhat-cop/helm-charts/pull/130

#### How do we test this?
Check CI goes green

cc: @redhat-cop/bats-library
