### PR TITLE
Add helm dep up step to cover subchart dependencies

### DIFF
--- a/src/helm.bash
+++ b/src/helm.bash
@@ -24,6 +24,10 @@ helm_template() {
   local output_file
   output_file="${tmp_write_dir}/templates.yaml"
   lint_output_file="${tmp_write_dir}/linting.output"
+  # Fetch dependencies
+  if ! return_message=$(eval "helm dep up ${chart_dir}") ; then
+    fail "# FATAL-ERROR: (helm.bash): helm dependencies update failed: ${return_message}" || return $?
+  fi
 
   # Safety check to make sure nothing above silently failed
   if ! return_message=$(eval "helm template ${template_opts} ${chart_dir} > ${output_file}") ; then


### PR DESCRIPTION
#### What is this PR About?
This PR adds a `helm dep up` step for helm testing, to cover cases in which helm chart has a subchart specified

#### How do we test this?
Tests done: 
```
 ✓ helm_template

```

cc: @redhat-cop/bats-library
